### PR TITLE
Adding EntryPoint Hooks for Tool Extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 ]
 
 dynamic = ["version"]
-dependencies = ["Jinja2>=3"]
-requires-python = ">=3.6, <4"
+dependencies = ["Jinja2>=3", "importlib_metadata>=1.4; python_version < '3.10'"]
+requires-python = ">=3.9, <4"
 
 [project.urls]
 Homepage = "https://github.com/olofk/edalize"


### PR DESCRIPTION
We would like to extend edalize without adding a top-level "edalize" namespace package to our repo. 

This PR adds entry point hooks for tools without removing support for namespace packages. It additionally changes how the tools are resolved, first building a map, then accessing it. 

A warning is added for a non-ignored namespace package which does not have a package which 

Overall I think this is a cleaner method and would prefer namespace package extensions to be dropped, with a period of deprecation with a warning. 

TODO: Add docs and examples.  
TODO: Clarify error handling behavior. 
TODO: Clarify deprecation. 
TODO: Clarify tool precedence.
TODO: Add additional descriptive warnings for several common mistakes. E.G. improperly specifying the fq name of the class.  
